### PR TITLE
Questions séquentielles avec pubs obligatoires et images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.env*

--- a/src/components/AdBanner.tsx
+++ b/src/components/AdBanner.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * Simple advertisement banner displayed on every game page.
+ * In a real project this would load ads from a provider.
+ */
+export default function AdBanner() {
+  return (
+    <div className="border p-4 text-center mb-4 bg-gray-100">
+      Publicité - merci de désactiver votre bloqueur de pubs
+    </div>
+  );
+}

--- a/src/pages/game/[game].tsx
+++ b/src/pages/game/[game].tsx
@@ -1,0 +1,50 @@
+import { useRouter } from 'next/router';
+import React, { useState } from 'react';
+import AdBanner from '../../components/AdBanner';
+
+const gameData: Record<string, { name: string; questions: string[] }> = {
+  maths: {
+    name: 'Maths',
+    questions: ['Combien font 2 + 2 ?', 'Combien font 3 x 3 ?', 'Combien font 10 / 2 ?'],
+  },
+  history: {
+    name: 'Histoire',
+    questions: [
+      'Qui a découvert l\'Amérique ?',
+      'En quelle année a eu lieu la Révolution française ?',
+      'Qui était le premier président de la République française ?',
+    ],
+  },
+};
+
+export default function GamePage() {
+  const router = useRouter();
+  const { game } = router.query as { game?: string };
+  const [index, setIndex] = useState(0);
+
+  if (!game || !gameData[game]) {
+    return <p>Jeu inconnu</p>;
+  }
+
+  const questions = gameData[game].questions;
+  const currentQuestion = questions[index];
+  const isLast = index === questions.length - 1;
+
+  return (
+    <div className="p-6">
+      <AdBanner />
+      <h1 className="text-xl mb-4">{gameData[game].name}</h1>
+      <p className="mb-4">{currentQuestion}</p>
+      {!isLast ? (
+        <button
+          onClick={() => setIndex(index + 1)}
+          className="px-4 py-2 bg-green-500 text-white rounded"
+        >
+          Question suivante
+        </button>
+      ) : (
+        <p>Fin du questionnaire</p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import React from 'react';
+
+const games = [
+  {
+    slug: 'maths',
+    name: 'Maths',
+    image: 'https://via.placeholder.com/150/92c952',
+  },
+  {
+    slug: 'history',
+    name: 'Histoire',
+    image: 'https://via.placeholder.com/150/771796',
+  },
+];
+
+export default function Home() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl mb-6">Choisir un jeu</h1>
+      <ul className="space-y-8">
+        {games.map((g) => (
+          <li key={g.slug} className="flex flex-col items-start">
+            <Link
+              href={`/game/${g.slug}`}
+              className="px-4 py-2 bg-blue-500 text-white rounded"
+            >
+              {g.name}
+            </Link>
+            <img
+              src={g.image}
+              alt={`Illustration pour ${g.name}`}
+              className="mt-2 w-48 h-32 object-cover"
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé
- Affichage des questions une par une pour chaque jeu
- Ajout d'une bannière publicitaire obligatoire sur les pages de jeu
- Illustrations sous chaque bouton de jeu sur la page d'accueil

## Tests
- `npm test` *(erreur : script manquant)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689a09dea1108324899467fe50b30761